### PR TITLE
From fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ To set these parameters, confer the configuration file schema.
 TODO
 To perform a single-point calibration, send in a known wavelength and find the position on the camera.
 
-A more convenient approximation measures displacement from the nominal ray. 
-Suppose the lens is aligned so that a normal ray hits the center of the camera.  
+A more convenient approximation measures displacement from the nominal ray.
+Suppose the lens is aligned so that a normal ray hits the center of the camera.
 We can then describe deviations from the camera center in terms of the normal ray:
 $$ \delta x = f \tan \left(\beta - \beta_0 \right) $$
 Where $\beta_0$ is the special normal ray (that in turn is related to a special color).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $$ \frac{m \lambda}{d} = \sin \beta - \sin \alpha, $$
 where $m$ is the diffraction order and $d$ is the grating groove spacing.
 _Note that with a transmissive grating, the incidence angle is internal to the grating and will be affected by refraction._
 
-Some of the diffracted rays are captured with a lens and Fourier mapped on the camera.
+A cone of diffracted rays are captured with a lens and Fourier mapped on the camera.
 The lens and camera are aligned such that the normal ray hits the center of the camera.
 The diffracted rays angles are related to the camera pixel position by:
 $$ \delta x = f \tan \left( \beta - \beta_0 \right), $$
@@ -32,7 +32,7 @@ $\delta x$ is the position along the plane of the camera, relative to the $\beta
 Using both equations, we can relate imaging position to wavelength:
 $$ \beta_0 + \tan^{-1} \frac{\delta x}{f} = \sin^{-1}\left(\frac{m\lambda}{d} - \sin \alpha \right) $$
 or
-$$ \lambda(\delta x; f, m, d, \alpha) = \frac{d}{m} \sin \left[ \beta_0 + \tan^{-1} \left(\frac{\delta x}{f}\right) \right] + \sin\alpha $$
+$$ \lambda(\delta x; f, m, d, \alpha, \beta_0) = \frac{d}{m} \sin \left[ \beta_0 + \tan^{-1} \left(\frac{\delta x}{f}\right) \right] + \sin\alpha $$
 To set these parameters, confer the configuration file schema.
 
 ## An example calibration routine
@@ -40,14 +40,10 @@ To set these parameters, confer the configuration file schema.
 TODO
 To perform a single-point calibration, send in a known wavelength and find the position on the camera.
 
-A more convenient approximation measures displacement from the nominal ray.
-Suppose the lens is aligned so that a normal ray hits the center of the camera.
+A more convenient approximation measures displacement from the nominal ray. 
+Suppose the lens is aligned so that a normal ray hits the center of the camera.  
 We can then describe deviations from the camera center in terms of the normal ray:
 $$ \delta x = f \tan \left(\beta - \beta_0 \right) $$
 Where $\beta_0$ is the special normal ray (that in turn is related to a special color).
 Since angles are small, we can use the paraxial approximation:
 $$ \delta x \approx f \frac{\beta - \beta_0}{}$$
-
-## maintainers
-
-- [Jason Scheeler](https://github.com/jscheeler1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "yaqd-core>=2021.2.0",
-    "instrumental-lib",
+    "instrumental-lib[cameras.picam]",
     "numpy",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ classifiers = [
 ]
 dynamic = ["version", "description"]
 
+[project.scripts]
+yaqd-pi-proem = "yaqd_pi._pi_proem:PiProem.main"
+
 [project.urls]
 Homepage = "https://yaq.fyi"
 Source = "https://github.com/yaq-project/yaqd-pi"
@@ -37,8 +40,9 @@ Issues = "https://github.com/yaq-project/yaqd-pi/issues"
 dev = ["black", "pre-commit"]
 gui = ["yaqc", "matplotlib", "click"]
 
-[project.scripts]
-yaqd-pi-proem = "yaqd_pi._pi_proem:PiProem.main"
+[[tool.mypy.overrides]]
+module = ["instrumental.drivers.*"]
+ignore_missing_imports = true
 
 [tool.black]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "yaqd-pi"
 authors = [
     {name="Jason Scheeler"},
-    {name="Dan Kohler", email="ddkohler@wisc.edu"}
+    {name="Dan Kohler"}
 ]
 readme = "README.md"
 requires-python = ">=3.7"

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -25,7 +25,9 @@ def main(port: int, host):
     x = cam.get_mappings()["x_index"]
     y = cam.get_mappings()["y_index"]
 
-    fig, (ax, opt1, opt2, opt3) = plt.subplots(nrows=4, height_ratios=[10, 1, 1, 1], gridspec_kw={"hspace":0.1})
+    fig, (ax, opt1, opt2, opt3) = plt.subplots(
+        nrows=4, height_ratios=[10, 1, 1, 1], gridspec_kw={"hspace": 0.1}
+    )
 
     try:
         y0 = cam.get_measured()["mean"]
@@ -37,7 +39,9 @@ def main(port: int, host):
     integration = Slider(
         opt1, "integration time (ms)", 33, 1e3, valstep=1, valinit=cam.get_exposure_time()
     )
-    acquisition = Slider(opt2, "acquisitions (2^x)", 0, 8, valinit=int(np.log2(cam.get_readout_count())), valstep=1)
+    acquisition = Slider(
+        opt2, "acquisitions (2^x)", 0, 8, valinit=int(np.log2(cam.get_readout_count())), valstep=1
+    )
     measure_button = CheckButtons(opt3, labels=["call measure"], label_props=dict(fontsize=[20]))
 
     state = {"current": 0, "next": 0}

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -48,7 +48,7 @@ def main(port: int, host):
                 ax.set_title(f"ID {data['measurement_id']}")
                 art.set_data(data["mean"])
             except Exception as e:
-                logger.error(exc_info=e, stack_info=True)
+                logger.error("", exc_info=e, stack_info=True)
                 return
             art.set_norm(Normalize())
             fig.canvas.draw_idle()
@@ -63,7 +63,7 @@ def main(port: int, host):
             update_line(measured)
         except Exception as e:
             logger.error(state, exc_info=e)
-            if e == ConnectionError:
+            if e == ConnectionError or e == ConnectionRefusedError:
                 pass
 
     timer = fig.canvas.new_timer(interval=200)

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -51,11 +51,12 @@ def main(port: int, host):
         if ax.get_title() != title.format(data["measurement_id"]):
             try:
                 ax.set_title(f"ID {data['measurement_id']}")
-                art.set_data(data["mean"])
+                if data["measurement_id"]:
+                    art.set_data(data["mean"])
+                    art.set_norm(norm())
             except Exception as e:
                 logger.error("", exc_info=e, stack_info=True)
                 return
-            art.set_norm(norm())
             fig.canvas.draw_idle()
 
     def submit(measure=False):
@@ -65,7 +66,8 @@ def main(port: int, host):
                     state["next"] = cam.measure()
             measured = cam.get_measured()
             state["current"] = measured["measurement_id"]
-            update_plot(measured)
+            if state["current"]:
+                update_plot(measured)
         except Exception as e:
             logger.error(state, exc_info=e)
             if e == ConnectionError or e == ConnectionRefusedError:

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -47,7 +47,7 @@ def main(port: int, host):
     state = {"current": 0, "next": 0}
     title = "ID {}"
 
-    def update_line(data):
+    def update_plot(data):
         if ax.get_title() != title.format(data["measurement_id"]):
             try:
                 ax.set_title(f"ID {data['measurement_id']}")
@@ -65,7 +65,7 @@ def main(port: int, host):
                     state["next"] = cam.measure()
             measured = cam.get_measured()
             state["current"] = measured["measurement_id"]
-            update_line(measured)
+            update_plot(measured)
         except Exception as e:
             logger.error(state, exc_info=e)
             if e == ConnectionError or e == ConnectionRefusedError:

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -137,8 +137,8 @@ class PiProem(HasMapping, HasMeasureTrigger):
         readouts = np.asarray(readouts)
         mean = readouts.mean(axis=(0, 1, 2))
         if readouts > 2:  # replace hot pixels with median value
-            hot = (readouts.max(axis=(0,1,2)) / mean) > 3
-            median = np.median(readouts, axis=(0,1,2))
+            hot = (readouts.max(axis=(0, 1, 2)) / mean) > 3
+            median = np.median(readouts, axis=(0, 1, 2))
             mean[hot] = median[hot]
             self.logger.info(f"number of hot pixels: {hot.sum()}")
         return {"mean": np.rot90(mean, 1)}

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -138,7 +138,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
         mean = readouts.mean(axis=(0, 1, 2))
         if np.prod(readouts.shape[:3]) > 2:  # replace hot pixels with median value
             maxes = readouts.max(axis=(0, 1, 2))
-            mean_without_max = (mean * actual - maxes) / (actual-1)
+            mean_without_max = (mean * actual - maxes) / (actual - 1)
             hot = maxes / mean_without_max > 3
             self.logger.info(f"{hot.sum()} hot pixels")
             # median = np.median(readouts, axis=(0, 1, 2))

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -77,7 +77,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
         readouts = []  # readouts[readout][readout_frame][frame roi]
         expected_readouts = self.get_readout_count()
         wait = min(self.get_exposure_time(), 50)  # ms
-        timeout = self.get_exposure_time() * 1.2 # ms
+        timeout = self.get_exposure_time() * 1.2  # ms
 
         while not readouts:  # reattempt acquisition if we didn't get anything
             running = True
@@ -100,13 +100,17 @@ class PiProem(HasMapping, HasMeasureTrigger):
                         if i > 100 and not (i % 100):
                             # ...however, if timeouts are excessive, the acquisition broke somehow
                             dt = time.time() - start
-                            self.logger.info("; ".join([
-                                f"waits={i}",
-                                f"acquisition running? {self.proem._dev.IsAcquisitionRunning()}",
-                                f"commited? {self.proem._dev.AreParametersCommitted()}",
-                                f"dt={dt:0.2f} sec"])
+                            self.logger.info(
+                                "; ".join(
+                                    [
+                                        f"waits={i}",
+                                        f"acquisition running? {self.proem._dev.IsAcquisitionRunning()}",
+                                        f"commited? {self.proem._dev.AreParametersCommitted()}",
+                                        f"dt={dt:0.2f} sec",
+                                    ]
+                                )
                             )
-                            if dt > timeout/1e3:
+                            if dt > timeout / 1e3:
                                 self.proem._dev.StopAcquisition()
                                 self.logger.error("timeout")
                                 running = False
@@ -129,7 +133,9 @@ class PiProem(HasMapping, HasMeasureTrigger):
                     start = time.time()
                     i = 0
             if (actual := len(readouts)) != expected_readouts:
-                self.logger.warning(f"expected {expected_readouts} images, but got {actual}; will loop continue? {bool(not readouts)}")
+                self.logger.warning(
+                    f"expected {expected_readouts} images, but got {actual}; will loop continue? {bool(not readouts)}"
+                )
         return {"mean": np.rot90(np.asarray(readouts).mean(axis=(0, 1, 2)), 1)}
 
     def _gen_spectral_mapping(self):

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -3,9 +3,21 @@ __all__ = ["PiProem"]
 import asyncio
 import numpy as np
 
-from yaqd_core import HasMapping, HasMeasureTrigger
+from yaqd_core import HasMapping, HasMeasureTrigger, logging
 
 from ._roi import ROI_native, ROI_UI, ui_to_native, native_to_ui
+
+root = logging.getLogger("")
+logging.getLogger("nicelib.nicelib").setLevel(logging.WARNING)
+logging.getLogger("instrumental.drivers").setLevel(logging.WARNING)
+
+from instrumental.drivers.cameras.picam import (
+    list_instruments,
+    PicamError,
+    PicamCamera,
+    PicamEnums,
+)
+
 
 
 class PiProem(HasMapping, HasMeasureTrigger):
@@ -30,12 +42,6 @@ class PiProem(HasMapping, HasMeasureTrigger):
         # I need to import these only after our daemon logger is initiated
         # DDK 2025-06-05
         self.logger.info("initializing picam. This can take a few seconds...")
-        from instrumental.drivers.cameras.picam import (
-            list_instruments,
-            PicamError,
-            PicamCamera,
-            PicamEnums,
-        )
 
         self.PicamEnums = PicamEnums
         self.PicamError = PicamError

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -2,6 +2,7 @@ __all__ = ["PiProem"]
 
 import asyncio
 import numpy as np
+import time
 
 from yaqd_core import HasMapping, HasMeasureTrigger, logging
 
@@ -19,7 +20,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
         super().__init__(name, config, config_filepath)
 
         if config.get("emulate"):
-            from instrumental.drivers.cameras.picam import sdk  # type: ignore
+            from instrumental.drivers.cameras.picam import sdk
 
             self.logger.info("Starting Emulated camera")
             sdk.connect_demo_camera(PicamEnums.Model.ProEMHS512BExcelon, "demo")
@@ -30,9 +31,6 @@ class PiProem(HasMapping, HasMeasureTrigger):
         self._channel_mappings = {"mean": ["y_index", "x_index"]}
         self._mapping_units = {"y_index": "None", "x_index": "None"}
 
-        # somehow instrumental overrides our logger...
-        # I need to import these only after our daemon logger is initiated
-        # DDK 2025-06-05
         self.logger.info("initializing picam. This can take a few seconds...")
         from instrumental.drivers.cameras.picam import (
             list_instruments,
@@ -79,27 +77,41 @@ class PiProem(HasMapping, HasMeasureTrigger):
         readouts = []  # readouts[readout][readout_frame][frame roi]
         expected_readouts = self.get_readout_count()
         wait = min(self.get_exposure_time(), 50)  # ms
-        # ensure we do not attempt measuring with uncommitted parameters:
-        if not self.proem._dev.AreParametersCommitted():
-            self.proem.commit_parameters()
-            self.logger.info("parameters updated")
+        timeout = self.get_exposure_time() * 1.2 # ms
+
         while not readouts:  # reattempt acquisition if we didn't get anything
             running = True
             i = 0
             try:
-                self.proem._dev.StartAcquisition()
+                if not self.proem._dev.IsAcquisitionRunning():
+                    self.proem._dev.StartAcquisition()
             except Exception as e:
-                self.logger.error(exc_info=e, stack_info=True)
+                self.logger.error("", exc_info=True, stack_info=True)
                 raise e
-            while running:
+            start = time.time()
+            while running:  # grab readouts
                 try:
-                    # wait is blocking, so use short waits and ignore timeouts
+                    # wait is blocking, so use short waits and ignore timeouts...
                     available_data, status = self.proem._dev.WaitForAcquisitionUpdate(wait)
                 except Exception as e:
                     if e.code == self.PicamEnums.Error.TimeOutOccurred:
-                        await asyncio.sleep(0)
-                        self.logger.debug(f"waits={i}")
                         i += 1
+                        await asyncio.sleep(0)
+                        if i > 100 and not (i % 100):
+                            # ...however, if timeouts are excessive, the acquisition broke somehow
+                            dt = time.time() - start
+                            self.logger.info("; ".join([
+                                f"waits={i}",
+                                f"acquisition running? {self.proem._dev.IsAcquisitionRunning()}",
+                                f"commited? {self.proem._dev.AreParametersCommitted()}",
+                                f"dt={dt:0.2f} sec"])
+                            )
+                            if dt > timeout/1e3:
+                                self.proem._dev.StopAcquisition()
+                                self.logger.error("timeout")
+                                running = False
+                        else:
+                            self.logger.debug(f"waits={i}")
                         continue
                     else:
                         self.proem._dev.StopAcquisition()
@@ -114,8 +126,10 @@ class PiProem(HasMapping, HasMeasureTrigger):
                         readouts.extend(
                             self.proem._extract_available_data(available_data, copy=True)
                         )
+                    start = time.time()
+                    i = 0
             if (actual := len(readouts)) != expected_readouts:
-                self.logger.warning(f"expected {expected_readouts} images, but got {actual}")
+                self.logger.warning(f"expected {expected_readouts} images, but got {actual}; will loop continue? {bool(not readouts)}")
         return {"mean": np.rot90(np.asarray(readouts).mean(axis=(0, 1, 2)), 1)}
 
     def _gen_spectral_mapping(self):
@@ -250,6 +264,9 @@ class PiProem(HasMapping, HasMeasureTrigger):
         self._loop.create_task(self._check_temp_stabilized())
 
     async def _check_temp_stabilized(self):
+        # DDK: so far, I can only get these values to refresh when I actually commit parameters
+        # (i.e. I cannot just call the following function; the parameters have to be different)
+        self.proem.commit_parameters()  # I think this updates the temperatures as well?
         set_temp = self.proem.params.SensorTemperatureSetPoint.get_value()
         while (status := self.proem.params.SensorTemperatureStatus.get_value().name) != "Locked":
             self.logger.warning(

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -161,7 +161,6 @@ class PiProem(HasMapping, HasMeasureTrigger):
         else:
             self.logger.info("tried to stop acquisition, but already stopped.")
 
-
     def _gen_spectral_mapping(self):
         """get map corresponding to static aoi and wavelength range."""
         spec = self._config["spectrometer"]

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -136,7 +136,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
         self._stop_acquisition()
         readouts = np.asarray(readouts)
         mean = readouts.mean(axis=(0, 1, 2))
-        if readouts > 2:  # replace hot pixels with median value
+        if np.prod(readouts.shape[:3]) > 2:  # replace hot pixels with median value
             hot = (readouts.max(axis=(0, 1, 2)) / mean) > 3
             median = np.median(readouts, axis=(0, 1, 2))
             mean[hot] = median[hot]

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -11,18 +11,6 @@ root = logging.getLogger("")
 logging.getLogger("nicelib.nicelib").setLevel(logging.WARNING)
 logging.getLogger("instrumental.drivers").setLevel(logging.WARNING)
 
-try:
-    from instrumental.drivers.cameras.picam import (
-        list_instruments,
-        PicamError,
-        PicamCamera,
-        PicamEnums,
-    )
-except ModuleNotFoundError:
-    # if CI, we can ignore, we can ignore and at least get through the 
-    root.error(exc_info=True)
-
-
 
 class PiProem(HasMapping, HasMeasureTrigger):
     _kind = "pi-proem"
@@ -46,6 +34,12 @@ class PiProem(HasMapping, HasMeasureTrigger):
         # I need to import these only after our daemon logger is initiated
         # DDK 2025-06-05
         self.logger.info("initializing picam. This can take a few seconds...")
+        from instrumental.drivers.cameras.picam import (
+            list_instruments,
+            PicamError,
+            PicamCamera,
+            PicamEnums,
+        )
 
         self.PicamEnums = PicamEnums
         self.PicamError = PicamError

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -139,7 +139,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
         if np.prod(readouts.shape[:3]) > 2:  # replace hot pixels with median value
             maxes = readouts.max(axis=(0, 1, 2))
             mean_without_max = (mean * actual - maxes) / (actual - 1)
-            hot = ((maxes-400) / (mean_without_max-400) > 3) & (maxes > 800)
+            hot = ((maxes - 400) / (mean_without_max - 400) > 3) & (maxes > 800)
             # 400 subtraction helps with sensitivity; getting too close to true baseline might create divergence due to zero counts
             # second clause is to avoid accidentally removing noise from baseline
             self.logger.info(f"{hot.sum()} hot pixels")

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -11,12 +11,17 @@ root = logging.getLogger("")
 logging.getLogger("nicelib.nicelib").setLevel(logging.WARNING)
 logging.getLogger("instrumental.drivers").setLevel(logging.WARNING)
 
-from instrumental.drivers.cameras.picam import (
-    list_instruments,
-    PicamError,
-    PicamCamera,
-    PicamEnums,
-)  # type: ignore
+try:
+    from instrumental.drivers.cameras.picam import (
+        list_instruments,
+        PicamError,
+        PicamCamera,
+        PicamEnums,
+    )
+except ModuleNotFoundError:
+    # if CI, we can ignore, we can ignore and at least get through the 
+    root.error(exc_info=True)
+
 
 
 class PiProem(HasMapping, HasMeasureTrigger):

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -190,9 +190,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
             return value
 
         def set_parameter(val):
-            self._loop.create_task(self._set_when_ready(
-                _set, param, val
-            ))
+            self._loop.create_task(self._set_when_ready(_set, param, val))
 
         return set_parameter, get_parameter, parameter_type
 

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -214,7 +214,7 @@ class PiProem(HasMapping, HasMeasureTrigger):
             param_enums = list(
                 filter(lambda x: my_param.can_set(x), getattr(self.PicamEnums, param))
             )
-            _set = lambda val: my_param.set_value(param_enums[val])
+            _set = lambda val: my_param.set_value([i for i in param_enums if i.name == val][0])
             _get = lambda _: my_param.get_value().name
             parameter_type = lambda: [i.name for i in param_enums]
         else:

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -107,7 +107,9 @@ class PiProem(HasMapping, HasMeasureTrigger):
                                 )
                             )
                             if dt > timeout / 1e3:
-                                self.logger.info("measure is taking too long; retrying measurement")
+                                self.logger.info(
+                                    "measure is taking too long; retrying measurement"
+                                )
                                 await self._stop_acquisition()
                                 self.logger.error("timeout")
                                 break

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -16,7 +16,7 @@ from instrumental.drivers.cameras.picam import (
     PicamError,
     PicamCamera,
     PicamEnums,
-)
+)  # type: ignore
 
 
 class PiProem(HasMapping, HasMeasureTrigger):

--- a/yaqd_pi/_pi_proem.py
+++ b/yaqd_pi/_pi_proem.py
@@ -139,7 +139,9 @@ class PiProem(HasMapping, HasMeasureTrigger):
         if np.prod(readouts.shape[:3]) > 2:  # replace hot pixels with median value
             maxes = readouts.max(axis=(0, 1, 2))
             mean_without_max = (mean * actual - maxes) / (actual - 1)
-            hot = maxes / mean_without_max > 3
+            hot = ((maxes-400) / (mean_without_max-400) > 3) & (maxes > 800)
+            # 400 subtraction helps with sensitivity; getting too close to true baseline might create divergence due to zero counts
+            # second clause is to avoid accidentally removing noise from baseline
             self.logger.info(f"{hot.sum()} hot pixels")
             # median = np.median(readouts, axis=(0, 1, 2))
             mean[hot] = mean_without_max[hot]

--- a/yaqd_pi/pi-proem.avpr
+++ b/yaqd_pi/pi-proem.avpr
@@ -438,7 +438,7 @@
             "getter": "get_exposure_time",
             "limits_getter": null,
             "options_getter": null,
-            "record_kind": "metadata",
+            "record_kind": "data",
             "setter": "set_exposure_time",
             "type": "float",
             "units_getter": "get_exposure_time_units"
@@ -449,7 +449,7 @@
             "getter": "get_readout_count",
             "limits_getter": null,
             "options_getter": null,
-            "record_kind": "metadata",
+            "record_kind": "data",
             "setter": "set_readout_count",
             "type": "int",
             "units_getter": null

--- a/yaqd_pi/pi-proem.toml
+++ b/yaqd_pi/pi-proem.toml
@@ -104,14 +104,14 @@ getter = "get_exposure_time"
 setter = "set_exposure_time"
 units_getter = "get_exposure_time_units"
 control_kind = "hinted"
-record_kind = "metadata"
+record_kind = "data"
 
 [properties.readout_count]
 type = "int"
 getter = "get_readout_count"
 setter = "set_readout_count"
 control_kind = "hinted"
-record_kind = "metadata"
+record_kind = "data"
 
 [properties.analog_gain]
 type = "string"


### PR DESCRIPTION
- update property setters to avoid errors involved with setting during acquisition
- moved instrumental lib imports outside class
- exposure time and readout count record_type promoted to data (so it can change during the course of a scan)
- rework measurement

note that moving the instrumental imports broke entry point checkers--they cannot account for the dynamic library creation (need dlls to compose these libraries)